### PR TITLE
feat: add rustowl plugin

### DIFF
--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -90,6 +90,14 @@
       sha256 = "sha256-SSLrY2+0shDy/gvZeFmMGlLEZdtbMQT7XBS0WvF8X98=";
     };
   };
+  rustowl-nvim = {
+    pname = "rustowl-nvim";
+    version = "0.4.0";
+    src = fetchurl {
+      url = "https://github.com/cordx56/rustowl/archive/refs/tags/v0.4.0.tar.gz";
+      sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+  };
   vim-stylus = {
     pname = "vim-stylus";
     version = "99031823d216c4433fb5c2661a33a43fbebaff61";

--- a/nix/plugins.nix
+++ b/nix/plugins.nix
@@ -66,6 +66,7 @@ let
     # Rust
     rustaceanvim
     crates-nvim
+    rustowl-nvim
 
     # Completion
     blink-cmp

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -48,6 +48,11 @@ src.git = "https://github.com/wavded/vim-stylus"
 src.branch = "master"
 fetch.github = "wavded/vim-stylus"
 
+[rustowl-nvim]
+src.github = "cordx56/rustowl"
+src.prefix = "v"
+fetch.url = "https://github.com/cordx56/rustowl/archive/refs/tags/v$ver.tar.gz"
+
 [vimdoc-ja]
 src.git = "https://github.com/vim-jp/vimdoc-ja"
 src.branch = "master"

--- a/nvim/lua/plugins/rustowl.lua
+++ b/nvim/lua/plugins/rustowl.lua
@@ -1,0 +1,14 @@
+return {
+    name = "rustowl",
+    dir = "@rustowl_nvim@",
+    lazy = false,
+    opts = {
+        client = {
+            on_attach = function(_, buffer)
+                vim.keymap.set("n", "<leader>o", function()
+                    require("rustowl").toggle(buffer)
+                end, { buffer = buffer, desc = "Toggle RustOwl" })
+            end,
+        },
+    },
+}


### PR DESCRIPTION
## Summary

- [cordx56/rustowl](https://github.com/cordx56/rustowl) の Neovim プラグインを追加
- Rust のオーナーシップとライフタイムをエディタ上で可視化するツール
- `<leader>o` で RustOwl の表示をトグル

## 変更内容

- `nvfetcher.toml`: rustowl-nvim のソース定義を追加
- `_sources/generated.nix`: rustowl-nvim v0.4.0 のソースエントリを追加（**要 `nvfetcher` 再実行でハッシュ更新**）
- `nix/plugins.nix`: Rust セクションに rustowl-nvim を追加
- `nvim/lua/plugins/rustowl.lua`: lazy.nvim 用の設定ファイルを作成

## TODO

- [ ] `nvfetcher` を実行して `_sources/generated.nix` の sha256 ハッシュを正しい値に更新する
- [ ] `rustowl` バイナリ (LSP サーバー) を PATH に含める（`cargo install rustowl` or nix パッケージ）

https://claude.ai/code/session_01RvQb9nRHCwEoxe5bV1Rwhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvQb9nRHCwEoxe5bV1Rwhb)_